### PR TITLE
poison.css fixes

### DIFF
--- a/stylesheets/poison.css
+++ b/stylesheets/poison.css
@@ -81,11 +81,6 @@ p.intro span.name
 span.quote {
 color: #E6E1E9;
 }
-span[style="color:orange;font-weight:bold"]
-{
-	color: #D880FC!important;
-
-}
 a:hover, p.intro a.post_no:hover
 {
 	color: #EDEDED!important;


### PR DESCRIPTION
Fixes post.reply.highlighted being the same color as post.reply. This makes it impossible to tell which post you are highlighting when you mouse over a post or follow a link to a specific post.
