### PR TITLE
Fix navbar color for desktop

### DIFF
--- a/stylesheets/dark.css
+++ b/stylesheets/dark.css
@@ -247,16 +247,6 @@ table.modlog tr th
 	color: #AAA;
 }
 
-.desktop-style div.boardlist:not(.bottom) {
-  text-shadow: black 1px 1px 1px, black -1px -1px 1px, black -1px 1px 1px, black 1px -1px 1px;
-  background-color: #666666;
-}
-
-
-.desktop-style div.boardlist:not(.bottom):hover, .desktop-style div.boardlist:not(.bottom).cb-menu {
-  background-color: rgba(30%, 30%, 30%, 0.65);
-}
-
 div.report 
 {
 	color: #666;


### PR DESCRIPTION
Just saw a weird color for the boardlist/nav-bar on my desktop. This gets rid of the light grey background so it looks like it did pre vichan merge.