### PR TITLE
Tiny fix for background images in lainchan's radio.html page.

### DIFF
--- a/templates/themes/irc/irc.html
+++ b/templates/themes/irc/irc.html
@@ -1,6 +1,6 @@
 {% filter remove_whitespace %}
 <!DOCTYPE html>
-<html>
+<html style="height:100vh; width:100%;">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <title>{{ settings.title }}</title>
@@ -9,7 +9,7 @@
     <link rel="stylesheet" media="screen" href="/stylesheets/cyberpunk.css"/>
 	<link rel="stylesheet" href="/stylesheets/font-awesome/css/font-awesome.min.css">
   </head>
-  <body style="background-image: url(/bg.php)">
+  <body style="background-image: url(/bg.php); background-size:cover; background-repeat:no-repeat; height:100vh; width: inherit; margin:none; padding:none; overflow-x:hidden; overflow-y:hidden;">
     <div class="bar top">
       {{ boardlist.top }}
 	</div>


### PR DESCRIPTION
Quick additions to the inline styles of html and body so the background-image doesn't spew all over the place in lainchan radio.
This is how it usually looks like without this change:
![lain1](https://cloud.githubusercontent.com/assets/10522936/8274045/ce818a9a-1854-11e5-8390-4b8fbd2f836a.PNG)
...and after:
![lain2](https://cloud.githubusercontent.com/assets/10522936/8274046/ce848b82-1854-11e5-99cc-5d355a588f72.PNG)

