### PR TITLE
make the catalog show the board name in the title

### DIFF
--- a/templates/themes/catalog/catalog.html
+++ b/templates/themes/catalog/catalog.html
@@ -7,7 +7,7 @@
 		active_page = "catalog";
 	</script>
 	{% include 'header.html' %}
-	<title>{{ settings.title }}</title>
+	<title>{{ settings.title }} (/{{ board }}/)</title>
 </head>
 <body class="theme-catalog">
 	<div class="topbar">


### PR DESCRIPTION
Currently: Having tabs open for /foo/ /bar/ and /baz/ catalogs, tabs would be listed as [Catalog] [Catalog] [Catalog] - confusing.
With the change: The tabs would now show [Catalog (/foo/)] [Catalog (/bar/)] [Catalog (/baz/)] - less confusing.