### PR TITLE
On hover post pop-up margin

### DIFF
--- a/js/post-hover.js
+++ b/js/post-hover.js
@@ -77,7 +77,7 @@ onready(function(){
 						.css('position', 'absolute')
 						.css('font-style', 'normal')
 						.css('z-index', '100')
-            .css('margin-left', '1em')
+						.css('margin-left', '1em')
 						.addClass('reply').addClass('post')
 						.insertAfter($link.parent())
 

--- a/js/post-hover.js
+++ b/js/post-hover.js
@@ -77,6 +77,7 @@ onready(function(){
 						.css('position', 'absolute')
 						.css('font-style', 'normal')
 						.css('z-index', '100')
+            .css('margin-left', '1em')
 						.addClass('reply').addClass('post')
 						.insertAfter($link.parent())
 


### PR DESCRIPTION
Without this margin you have to keep your mouse very still while
hovering a post quote for a post that is off-screen, otherwise, by
placing the mouse on the pop-up itself, the mouseout event is triggered
and the pop-up disappears, making for a very annoying user experience
when reading post pop-ups.

This patch separates the pop-up from the mouse so that this doesn't happen.