### PR TITLE
Board lock workaround

### DIFF
--- a/post.php
+++ b/post.php
@@ -17,7 +17,7 @@ if (get_magic_quotes_gpc()) {
 	$_POST = strip_array($_POST);
 }
 
-if ((!isset($_POST['mod']) || !$_POST['mod']) && $config['board_locked']) {
+if ((!isset($_POST['mod']) || !$_POST['mod']) && is_array($config['board_locked']) && in_array(strtolower($_POST["board"]), $config['board_locked'])) {
     error("Board is locked");
 }
 

--- a/post.php
+++ b/post.php
@@ -17,7 +17,9 @@ if (get_magic_quotes_gpc()) {
 	$_POST = strip_array($_POST);
 }
 
-if ((!isset($_POST['mod']) || !$_POST['mod']) && is_array($config['board_locked']) && in_array(strtolower($_POST["board"]), $config['board_locked'])) {
+if ((!isset($_POST['mod']) || !$_POST['mod'])
+	&& ($config['board_locked']===true
+		|| (is_array($config['board_locked']) && in_array(strtolower($_POST['board']), $config['board_locked'])))){
     error("Board is locked");
 }
 


### PR DESCRIPTION
Works around the fact that individual board configs are not loaded when posting by making locked boards a global setting that takes an array of boards

Obviously the proper fix is to correctly load the board configs but I can't be arsed.