### PR TITLE
fix mobile styling

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -4,13 +4,6 @@ div.sidearrows{
     display:none;
 }
 
-
-td{
-  
-}
-
-
-
 html, body {
     max-width: 100%!important;
     overflow-x: hidden!important;
@@ -30,15 +23,9 @@ div.pages{
 }
 
 div.boardlist.bottom {
- 
+
   text-align: center!important;
   display: none!important;
-}
-
-img.banner, img.board_image {
-
-   max-width: 100%!important;
-
 }
 
 .pintro{
@@ -107,7 +94,7 @@ main {
 /* Tables */
 table {
     margin: auto;
-   
+
 }
 table.board-list-table {
     width: 100%;
@@ -115,13 +102,13 @@ table.board-list-table {
 table tbody td {
     margin: 0;
     padding: 4px 15px 4px 4px;
-    
+
     text-align: left;
 }
 table thead th {
     border: 1px solid #000333;
     padding: 4px 15px 5px 5px;
-    
+
     background: #98E;
     color: #000333;
     text-align: left;
@@ -132,7 +119,7 @@ table tbody tr:nth-of-type( even ) {
 }
 
 tr{
-  
+
 }
 
 td.minimal,th.minimal {
@@ -244,7 +231,7 @@ h2 {
 }
 
 header {
-  margin: 1em 0;
+  margin: 2em 0;
 }
 
 h1 {
@@ -371,7 +358,7 @@ div.banner a:hover {
 img.banner,img.board_image {
   display: block;
   border: 1px solid #a9a9a9;
-  margin: 12px auto 0 auto;
+  margin: 3em auto 0 auto;
 }
 
 .post-image {
@@ -455,7 +442,7 @@ input.delete {
 div.post p {
     display: block;
     margin: 0;
-    
+
     line-height: 1.16em;
     font-size: 13px;
     min-height: 1.16em;
@@ -1231,10 +1218,10 @@ span.pln {
     clear: both;
     visibility: hidden;
     overflow: hidden;
-    
+
     font-size: 0px;
     line-height: 0px;
-    
+
     box-sizing: border-box;
     border: none;
     height: 0;
@@ -1249,7 +1236,7 @@ span.pln {
 /* Board List */
 div.boardlist {
     margin-top: 3px;
-    
+
     color: #89A;
     font-size: 9pt;
 }
@@ -1329,7 +1316,7 @@ div.boardlist a {
 }
 div.mix {
     display: inline-block;
-} 
+}
 
 /* Mona Font */
 .aa {
@@ -1721,12 +1708,12 @@ td.board-tags a.tag-link {
     aside.search-container .box {
         margin-right: 0;
     }
-    
+
     section.board-list {
         margin-top: 12px;
         width: 100%;
     }
-    
+
     table.board-list-table .board-meta,
     table.board-list-table .board-pph,
     table.board-list-table .board-tags {
@@ -1744,7 +1731,7 @@ td.board-tags a.tag-link {
 .announcement {
     font-size: 75%;
     padding-bottom: 1%;
-    margin-left: 5%; 
+    margin-left: 5%;
     margin-right: 5%;
 }
 
@@ -1812,5 +1799,30 @@ table.fileboard .intro a {
   margin-left: 0px;
 }
 
-  
+/* avoid ugly overflow for stuff */
+img, embed, object, video {
+    max-width: 100%;
+}
 
+/* boardlist gets all scrunched on small screens */
+@media screen and (max-width: 600px) {
+    header, img.board_image {
+        margin-top: 5em;
+    }
+}
+
+@media screen and (min-width: 700px) {
+    img.board_image {
+        margin-top: 2em;
+    }
+
+    .bar {
+        display: flex;
+        flex-flow: row wrap;
+        justify-content: center;
+    }
+
+    .bar > * {
+        flex: 1 1 auto;
+    }
+}

--- a/templates/themes/catalog/catalog.html
+++ b/templates/themes/catalog/catalog.html
@@ -2,6 +2,7 @@
 <!doctype html>
 <html>
 <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 	<script type='text/javascript'>
 		active_page = "catalog";
@@ -51,12 +52,12 @@
 				data-time="{{ post.time }}"
 				data-board="{{ post.board }}"
 			>
-                                <div class="thread grid-li grid-size-small">  
-                                        <a href="{{post.link}}">  
+                                <div class="thread grid-li grid-size-small">
+                                        <a href="{{post.link}}">
 						{% if post.youtube %}
-							<img src="//img.youtube.com/vi/{{ post.youtube }}/0.jpg" 
+							<img src="//img.youtube.com/vi/{{ post.youtube }}/0.jpg"
 						{% else %}
-							<img src="{{post.file}}" 
+							<img src="{{post.file}}"
 						{% endif %}
                                                  id="img-{{ post.id }}" data-subject="{% if post.subject %}{{ post.subject|e }}{% endif %}" data-name="{{ post.name|e }}" data-muhdifference="{{ post.muhdifference }}" class="{{post.board}} thread-image" title="{{post.bump|date('%b %d %H:%M')}}">
                                         </a>
@@ -79,12 +80,12 @@
                 {% endfor %}
                 </ul>
         </div>
-	
+
 	<hr/>
 	<footer>
 		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> +
 			<a href='https://int.vichan.net/devel/'>vichan</a> {{ config.version }} -
-		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group    
+		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
 		<br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2015 vichan-devel</p>
 	</footer>
 	<script type="text/javascript">{% raw %}

--- a/templates/themes/categories/frames.html
+++ b/templates/themes/categories/frames.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 	<link rel="stylesheet" media="screen" href="{{ config.url_stylesheet }}">
 	<style type="text/css">

--- a/templates/themes/categories/news.html
+++ b/templates/themes/categories/news.html
@@ -2,6 +2,7 @@
 <!doctype html>
 <html>
 <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 	<title>{{ settings.title }}</title>
 	<link rel="stylesheet" media="screen" href="{{ config.url_stylesheet }}"/>
@@ -12,7 +13,7 @@
 		<h1>{{ settings.title }}</h1>
 		<div class="subtitle">{{ settings.subtitle }}</div>
 	</header>
-	
+
 	<div class="ban">
 		{% if news|count == 0 %}
 			<p style="text-align:center" class="unimportant">{% trans %}(No news to show.){% endtrans %}</p>
@@ -30,11 +31,11 @@
 			{% endfor %}
 		{% endif %}
 	</div>
-	
+
         <footer>
-                <p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
+                <p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> +
                         <a href='https://int.vichan.net/devel/'>vichan</a> {{ config.version }} -
-                <br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group    
+                <br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
                 <br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2015 vichan-devel</p>
         </footer>
 </body>

--- a/templates/themes/categories/sidebar.html
+++ b/templates/themes/categories/sidebar.html
@@ -2,6 +2,7 @@
 <!doctype html>
 <html>
 <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 	<title>{{ settings.title }}</title>
 	<link rel="stylesheet" media="screen" href="{{ config.url_stylesheet }}"/>
@@ -23,7 +24,7 @@
 			</li>
 		</ul>
 	</fieldset>
-	
+
 	{% for category, boards in categories %}
 		<fieldset>
 			<legend>
@@ -36,7 +37,7 @@
 			{% endfor %}
 		</fieldset>
 	{% endfor %}
-	
+
 	{% for category, links in config.custom_categories %}
 		<fieldset>
 			<legend>

--- a/templates/themes/donate/donate.html
+++ b/templates/themes/donate/donate.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <title>{{ settings.title }}</title>
     <link rel="shortcut icon" href="/favicon.png">

--- a/templates/themes/frameset/frames.html
+++ b/templates/themes/frameset/frames.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 	<link rel="stylesheet" media="screen" href="{{ config.url_stylesheet }}">
 	<style type="text/css">

--- a/templates/themes/frameset/news.html
+++ b/templates/themes/frameset/news.html
@@ -2,6 +2,7 @@
 <!doctype html>
 <html>
 <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 	<title>{{ settings.title }}</title>
 	<link rel="stylesheet" media="screen" href="{{ config.url_stylesheet }}"/>
@@ -11,7 +12,7 @@
 		<h1>{{ settings.title }}</h1>
 		<div class="subtitle">{{ settings.subtitle }}</div>
 	</header>
-	
+
 	<div class="ban">
 		{% if news|count == 0 %}
 			<p style="text-align:center" class="unimportant">(No news to show.)</p>
@@ -29,11 +30,11 @@
 			{% endfor %}
 		{% endif %}
 	</div>
-	
+
         <footer>
-                <p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
+                <p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> +
                         <a href='https://int.vichan.net/devel/'>vichan</a> {{ config.version }} -
-                <br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group    
+                <br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
                 <br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2015 vichan-devel</p>
         </footer>
 </body>

--- a/templates/themes/frameset/sidebar.html
+++ b/templates/themes/frameset/sidebar.html
@@ -2,6 +2,7 @@
 <!doctype html>
 <html>
 <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 	<title>{{ settings.title }}</title>
 	<link rel="stylesheet" media="screen" href="{{ config.url_stylesheet }}"/>
@@ -23,7 +24,7 @@
 			</li>
 		</ul>
 	</fieldset>
-	
+
 	<fieldset>
 		<legend>Boards</legend>
 		<ul>

--- a/templates/themes/irc/irc.html
+++ b/templates/themes/irc/irc.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html style="height:100vh; width:100%;">
   <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <title>{{ settings.title }}</title>
     <link rel="shortcut icon" href="/favicon.png">

--- a/templates/themes/irc/radio.html
+++ b/templates/themes/irc/radio.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <title>{{ settings.title }}</title>
     <link rel="shortcut icon" href="/favicon.png">
@@ -21,7 +22,7 @@
 
 
     <div class="ban" style="text-align: left!important;">
-    	<h2>Web Client - Point your own clients to #lainchan on irc.freenode.net.</h2>		
+    	<h2>Web Client - Point your own clients to #lainchan on irc.freenode.net.</h2>
 	<iframe src="https://webchat.freenode.net?channels=%23lainchan&uio=MTE9MTMz98" width="766" height="400"></iframe>
     </div>
   </body>

--- a/templates/themes/radio/radio.html
+++ b/templates/themes/radio/radio.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <title>{{ settings.title }}</title>
     <link rel="shortcut icon" href="/favicon.png">
@@ -22,7 +23,7 @@
 
 
     <div class="ban" style="text-align: left!important;">
-    	<h2>Web Client - Point your own clients to #lainchan on irc.freenode.net.</h2>		
+    	<h2>Web Client - Point your own clients to #lainchan on irc.freenode.net.</h2>
 	<iframe src="https://webchat.freenode.net?channels=%23lainchan&uio=MTE9MTMz98" width="766" height="400"></iframe>
     </div>
   </body>

--- a/templates/themes/recent/recent.html
+++ b/templates/themes/recent/recent.html
@@ -2,6 +2,7 @@
 <!doctype html>
 <html>
 <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 	<title>{{ settings.title }}</title>
 	<link rel="stylesheet" media="screen" href="{{ config.root}}stylesheets/style.css"/>
@@ -26,7 +27,7 @@
 
  <br>
 
-     <div class="ban" id="global">      <h2>CYBERPUNK IS DEAD</h2>  Pour out the Soykaf, lurk, and read the <a href="https://lainchan.org/rules">rules</a> before posting!    </div> 
+     <div class="ban" id="global">      <h2>CYBERPUNK IS DEAD</h2>  Pour out the Soykaf, lurk, and read the <a href="https://lainchan.org/rules">rules</a> before posting!    </div>
 
     <br>
 
@@ -48,7 +49,7 @@
 			<ul>
 				{% for post in recent_posts %}
 					<li>
-						<strong>{{ post.board_name }}</strong>: 
+						<strong>{{ post.board_name }}</strong>:
 						<a href="{{ post.link }}">
 							{{ post.snippet }}
 						</a>

--- a/templates/themes/rules/rules.html
+++ b/templates/themes/rules/rules.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <title>{{ settings.title }}</title>
     <link rel="shortcut icon" href="/favicon.png">
@@ -42,7 +43,7 @@
       </ol>
     </div>
 
-   <div class="ban" id="tips"> 
+   <div class="ban" id="tips">
 <h2>PRO TIPS FOR MAXIMUM FUN:</h2>
       <ul>
 <li>The mods are not on powertrips, they are friendly and are trying to ensure the quality of lainchan, not belittle your ideas.</li>
@@ -93,11 +94,3 @@
   </body>
 </html>
 {% endfilter %}
-
-
-
-
-
-
-
-

--- a/templates/themes/zine/zine.html
+++ b/templates/themes/zine/zine.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <title>{{ settings.title }}</title>
     <link rel="shortcut icon" href="/favicon.png">


### PR DESCRIPTION
Fixes #53 and some of #26 
- added the meta viewport tag to any pages that didn't have it
- corrected max-width CSS for elements so they don't jump out of their parent container
- little media queries for banner + top-bar spacing
