### PR TITLE
add popup rule agreement page

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -2,7 +2,7 @@
 
 /*
  *  Copyright (c) 2010-2013 Tinyboard Development Group
- *
+ *  
  *  WARNING: This is a project-wide configuration file and is overwritten when upgrading to a newer
  *  version of Tinyboard. Please leave this file unchanged, or it will be a lot harder for you to upgrade.
  *  If you would like to make instance-specific changes to your own setup, please use instance-config.php.
@@ -109,7 +109,7 @@
 
 	/*
 	 * On top of the static file caching system, you can enable the additional caching system which is
-	 * designed to minimize SQL queries and can significantly increase speed when posting or using the
+	 * designed to minimize SQL queries and can significantly increase speed when posting or using the 
 	 * moderator interface. APC is the recommended method of caching.
 	 *
 	 * http://tinyboard.org/docs/index.php?p=Config/Cache
@@ -197,15 +197,15 @@
 	// http://www.projecthoneypot.org/httpbl.php
 	// $config['dnsbl'][] = array('<your access key>.%.dnsbl.httpbl.org', function($ip) {
 	//	$octets = explode('.', $ip);
-	//
+	//	
 	//	// days since last activity
 	//	if ($octets[1] > 14)
 	//		return false;
-	//
+	//	
 	//	// "threat score" (http://www.projecthoneypot.org/threat_info.php)
 	//	if ($octets[2] < 5)
 	//		return false;
-	//
+	//	
 	//	return true;
 	// }, 'dnsbl.httpbl.org'); // hide our access key
 
@@ -241,7 +241,7 @@
 
 	// How soon after regeneration do hashes expire (in seconds)?
 	$config['spam']['hidden_inputs_expire'] = 60 * 60 * 3; // three hours
-
+	
 	// Whether to use Unicode characters in hidden input names and values.
 	$config['spam']['unicode'] = true;
 
@@ -292,7 +292,7 @@
 	// Public and private key pair from https://www.google.com/recaptcha/admin/create
 	$config['recaptcha_public'] = '6LcXTcUSAAAAAKBxyFWIt2SO8jwx4W7wcSMRoN3f';
 	$config['recaptcha_private'] = '6LcXTcUSAAAAAOGVbVdhmEM1_SyRF4xTKe8jbzf_';
-
+	
 	// Ability to lock a board for normal users and still allow mods to post.  Could also be useful for making an archive board
 	$config['board_locked'] = false;
 
@@ -421,7 +421,7 @@
 	// 	),
 	// 	'action' => 'reject'
 	// );
-
+	
 	// Filter flood prevention conditions ("flood-match") depend on a table which contains a cache of recent
 	// posts across all boards. This table is automatically purged of older posts, determining the maximum
 	// "age" by looking at each filter. However, when determining the maximum age, Tinyboard does not look
@@ -502,9 +502,9 @@
 	$config['markup_urls'] = true;
 
 	// Optional URL prefix for links (eg. "http://anonym.to/?").
-	$config['link_prefix'] = '';
+	$config['link_prefix'] = ''; 
 	$config['url_ads'] = &$config['link_prefix'];	 // leave alias
-
+	
 	// Allow "uploading" images via URL as well. Users can enter the URL of the image and then Tinyboard will
 	// download it. Not usually recommended.
 	$config['allow_upload_by_url'] = false;
@@ -515,7 +515,7 @@
 	// as they are submitted and changes or censors particular words or phrases.
 
 	// For a normal string replacement:
-	// $config['wordfilters'][] = array('cat', 'dog');
+	// $config['wordfilters'][] = array('cat', 'dog');	
 	// Advanced raplcement (regular expressions):
 	// $config['wordfilters'][] = array('/ca[rt]/', 'dog', true); // 'true' means it's a regular expression
 
@@ -564,10 +564,10 @@
 	// that you will have to disable BOTH country_flags and contry_flags_condensed optimization (at least on a board
 	// where they are enabled).
 	$config['user_flag'] = false;
-
+	
 	// List of user_flag the user can choose. Flags must be placed in the directory set by $config['uri_flags']
 	$config['user_flags'] = array();
-	/* example: 
+	/* example: 
 	$config['user_flags'] = array (
 		'nz' => 'Nazi',
 		'cm' => 'Communist',
@@ -581,7 +581,7 @@
 
 	// Use semantic URLs for threads, like /b/res/12345/daily-programming-thread.html
 	$config['slugify'] = false;
-
+	
 	// Max size for slugs
 	$config['slug_max_size'] = 80;
 
@@ -650,10 +650,10 @@
 	// $config['additional_javascript'][] = 'js/multi_image.js';
 	$config['max_images'] = 1;
 
-	// Method to use for determing the max filesize.
+	// Method to use for determing the max filesize. 
 	// "split" means that your max filesize is split between the images. For example, if your max filesize
-	// is 2MB, the filesizes of all files must add up to 2MB for it to work.
-	// "each" means that each file can be 2MB, so if your max_images is 3, each post could contain 6MB of
+	// is 2MB, the filesizes of all files must add up to 2MB for it to work. 
+	// "each" means that each file can be 2MB, so if your max_images is 3, each post could contain 6MB of 
 	// images. "split" is recommended.
 	$config['multiimage_method'] = 'split';
 
@@ -680,7 +680,7 @@
 	 *   'gd'		   PHP GD (default). Only handles the most basic image formats (GIF, JPEG, PNG).
 	 *				  GD is a prerequisite for Tinyboard no matter what method you choose.
 	 *
-	 *   'imagick'	  PHP's ImageMagick bindings. Fast and efficient, supporting many image formats.
+	 *   'imagick'	  PHP's ImageMagick bindings. Fast and efficient, supporting many image formats. 
 	 *				  A few minor bugs. http://pecl.php.net/package/imagick
 	 *
 	 *   'convert'	  The command line version of ImageMagick (`convert`). Fixes most of the bugs in
@@ -707,18 +707,18 @@
 	// Ignored when $config['redraw_image'] is true. This is also used to adjust the Orientation tag when
 	//  $config['strip_exif'] is false and $config['convert_manual_orient'] is true.
 	$config['use_exiftool'] = false;
-
+	
 	// Redraw the image to strip any excess data (commonly ZIP archives) WARNING: This might strip the
 	// animation of GIFs, depending on the chosen thumbnailing method. It also requires recompressing
 	// the image, so more processing power is required.
 	$config['redraw_image'] = false;
-
+	
 	// Automatically correct the orientation of JPEG files using -auto-orient in `convert`. This only works
 	// when `convert` or `gm` is selected for thumbnailing. Again, requires more processing power because
 	// this basically does the same thing as $config['redraw_image']. (If $config['redraw_image'] is enabled,
 	// this value doesn't matter as $config['redraw_image'] attempts to correct orientation too.)
 	$config['convert_auto_orient'] = false;
-
+	
 	// Is your version of ImageMagick or GraphicsMagick old? Older versions may not include the -auto-orient
 	// switch. This is a manual replacement for that switch. This is independent from the above switch;
 	// -auto-orrient is applied when thumbnailing too.
@@ -800,7 +800,7 @@
 	$config['image_identification_google'] = true;
 	// Anime/manga search engine.
 	$config['image_identification_iqdb'] = false;
-
+	
 	// Set this to true if you're using a BSD
 	$config['bsd_md5'] = false;
 
@@ -982,10 +982,9 @@
 	// jQuery, you should first empty the array so that "js/query.min.js" can be the first, and then re-add
 	// "js/inline-expanding.js" or else the inline-expanding script might not interact properly with other
 	// scripts.
-	$config['additional_javascript'] = array();
-	$config['additional_javascript'][] = 'js/jquery.min.js';
-	$config['additional_javascript'][] = 'js/inline-expanding.js';
-	$config['additional_javascript'][] = 'js/rules-popup.js';
+	// $config['additional_javascript'] = array();
+	// $config['additional_javascript'][] = 'js/jquery.min.js';
+	// $config['additional_javascript'][] = 'js/inline-expanding.js';
 	// $config['additional_javascript'][] = 'js/auto-reload.js';
 	// $config['additional_javascript'][] = 'js/post-hover.js';
 	// $config['additional_javascript'][] = 'js/style-select.js';
@@ -1190,7 +1189,7 @@
 
 	// Website favicon.
 	// $config['url_favicon'] = '/favicon.gif';
-
+	
 	// Try not to build pages when we shouldn't have to.
 	$config['try_smarter'] = true;
 
@@ -1502,21 +1501,21 @@
 		'convert_args',
 		'db>password',
 	);
-
+	
 	$config['mod']['config'][JANITOR] = array(
 		'!', // Allow editing ONLY the variables listed (in this case, nothing).
 	);
-
+	
 	$config['mod']['config'][MOD] = array(
 		'!', // Allow editing ONLY the variables listed (plus that in $config['mod']['config'][JANITOR]).
 		'global_message',
 	);
-
+	
 	// Example: Disallow ADMIN from editing (and viewing) $config['db']['password'].
 	// $config['mod']['config'][ADMIN] = array(
 	// 	'db>password',
 	// );
-
+	
 	// Example: Allow ADMIN to edit anything other than $config['db']
 	// (and $config['mod']['config'][DISABLED]).
 	// $config['mod']['config'][ADMIN] = array(
@@ -1551,7 +1550,7 @@
 
 	// Limit of search results
     $config['search']['search_limit'] = 100;
-
+		
 	// Boards for searching
     //$config['search']['boards'] = array('a', 'b', 'c', 'd', 'e');
 
@@ -1569,7 +1568,7 @@
 
 	// event_handler('post', function($post) {
 	// 	// do something else
-	//
+	// 	
 	// 	// return an error (reject post)
 	// 	return 'Sorry, you cannot post that!';
 	// });

--- a/inc/config.php
+++ b/inc/config.php
@@ -2,7 +2,7 @@
 
 /*
  *  Copyright (c) 2010-2013 Tinyboard Development Group
- *  
+ *
  *  WARNING: This is a project-wide configuration file and is overwritten when upgrading to a newer
  *  version of Tinyboard. Please leave this file unchanged, or it will be a lot harder for you to upgrade.
  *  If you would like to make instance-specific changes to your own setup, please use instance-config.php.
@@ -109,7 +109,7 @@
 
 	/*
 	 * On top of the static file caching system, you can enable the additional caching system which is
-	 * designed to minimize SQL queries and can significantly increase speed when posting or using the 
+	 * designed to minimize SQL queries and can significantly increase speed when posting or using the
 	 * moderator interface. APC is the recommended method of caching.
 	 *
 	 * http://tinyboard.org/docs/index.php?p=Config/Cache
@@ -197,15 +197,15 @@
 	// http://www.projecthoneypot.org/httpbl.php
 	// $config['dnsbl'][] = array('<your access key>.%.dnsbl.httpbl.org', function($ip) {
 	//	$octets = explode('.', $ip);
-	//	
+	//
 	//	// days since last activity
 	//	if ($octets[1] > 14)
 	//		return false;
-	//	
+	//
 	//	// "threat score" (http://www.projecthoneypot.org/threat_info.php)
 	//	if ($octets[2] < 5)
 	//		return false;
-	//	
+	//
 	//	return true;
 	// }, 'dnsbl.httpbl.org'); // hide our access key
 
@@ -241,7 +241,7 @@
 
 	// How soon after regeneration do hashes expire (in seconds)?
 	$config['spam']['hidden_inputs_expire'] = 60 * 60 * 3; // three hours
-	
+
 	// Whether to use Unicode characters in hidden input names and values.
 	$config['spam']['unicode'] = true;
 
@@ -292,7 +292,7 @@
 	// Public and private key pair from https://www.google.com/recaptcha/admin/create
 	$config['recaptcha_public'] = '6LcXTcUSAAAAAKBxyFWIt2SO8jwx4W7wcSMRoN3f';
 	$config['recaptcha_private'] = '6LcXTcUSAAAAAOGVbVdhmEM1_SyRF4xTKe8jbzf_';
-	
+
 	// Ability to lock a board for normal users and still allow mods to post.  Could also be useful for making an archive board
 	$config['board_locked'] = false;
 
@@ -421,7 +421,7 @@
 	// 	),
 	// 	'action' => 'reject'
 	// );
-	
+
 	// Filter flood prevention conditions ("flood-match") depend on a table which contains a cache of recent
 	// posts across all boards. This table is automatically purged of older posts, determining the maximum
 	// "age" by looking at each filter. However, when determining the maximum age, Tinyboard does not look
@@ -502,9 +502,9 @@
 	$config['markup_urls'] = true;
 
 	// Optional URL prefix for links (eg. "http://anonym.to/?").
-	$config['link_prefix'] = ''; 
+	$config['link_prefix'] = '';
 	$config['url_ads'] = &$config['link_prefix'];	 // leave alias
-	
+
 	// Allow "uploading" images via URL as well. Users can enter the URL of the image and then Tinyboard will
 	// download it. Not usually recommended.
 	$config['allow_upload_by_url'] = false;
@@ -515,7 +515,7 @@
 	// as they are submitted and changes or censors particular words or phrases.
 
 	// For a normal string replacement:
-	// $config['wordfilters'][] = array('cat', 'dog');	
+	// $config['wordfilters'][] = array('cat', 'dog');
 	// Advanced raplcement (regular expressions):
 	// $config['wordfilters'][] = array('/ca[rt]/', 'dog', true); // 'true' means it's a regular expression
 
@@ -564,7 +564,7 @@
 	// that you will have to disable BOTH country_flags and contry_flags_condensed optimization (at least on a board
 	// where they are enabled).
 	$config['user_flag'] = false;
-	
+
 	// List of user_flag the user can choose. Flags must be placed in the directory set by $config['uri_flags']
 	$config['user_flags'] = array();
 	/* example: 
@@ -581,7 +581,7 @@
 
 	// Use semantic URLs for threads, like /b/res/12345/daily-programming-thread.html
 	$config['slugify'] = false;
-	
+
 	// Max size for slugs
 	$config['slug_max_size'] = 80;
 
@@ -650,10 +650,10 @@
 	// $config['additional_javascript'][] = 'js/multi_image.js';
 	$config['max_images'] = 1;
 
-	// Method to use for determing the max filesize. 
+	// Method to use for determing the max filesize.
 	// "split" means that your max filesize is split between the images. For example, if your max filesize
-	// is 2MB, the filesizes of all files must add up to 2MB for it to work. 
-	// "each" means that each file can be 2MB, so if your max_images is 3, each post could contain 6MB of 
+	// is 2MB, the filesizes of all files must add up to 2MB for it to work.
+	// "each" means that each file can be 2MB, so if your max_images is 3, each post could contain 6MB of
 	// images. "split" is recommended.
 	$config['multiimage_method'] = 'split';
 
@@ -680,7 +680,7 @@
 	 *   'gd'		   PHP GD (default). Only handles the most basic image formats (GIF, JPEG, PNG).
 	 *				  GD is a prerequisite for Tinyboard no matter what method you choose.
 	 *
-	 *   'imagick'	  PHP's ImageMagick bindings. Fast and efficient, supporting many image formats. 
+	 *   'imagick'	  PHP's ImageMagick bindings. Fast and efficient, supporting many image formats.
 	 *				  A few minor bugs. http://pecl.php.net/package/imagick
 	 *
 	 *   'convert'	  The command line version of ImageMagick (`convert`). Fixes most of the bugs in
@@ -707,18 +707,18 @@
 	// Ignored when $config['redraw_image'] is true. This is also used to adjust the Orientation tag when
 	//  $config['strip_exif'] is false and $config['convert_manual_orient'] is true.
 	$config['use_exiftool'] = false;
-	
+
 	// Redraw the image to strip any excess data (commonly ZIP archives) WARNING: This might strip the
 	// animation of GIFs, depending on the chosen thumbnailing method. It also requires recompressing
 	// the image, so more processing power is required.
 	$config['redraw_image'] = false;
-	
+
 	// Automatically correct the orientation of JPEG files using -auto-orient in `convert`. This only works
 	// when `convert` or `gm` is selected for thumbnailing. Again, requires more processing power because
 	// this basically does the same thing as $config['redraw_image']. (If $config['redraw_image'] is enabled,
 	// this value doesn't matter as $config['redraw_image'] attempts to correct orientation too.)
 	$config['convert_auto_orient'] = false;
-	
+
 	// Is your version of ImageMagick or GraphicsMagick old? Older versions may not include the -auto-orient
 	// switch. This is a manual replacement for that switch. This is independent from the above switch;
 	// -auto-orrient is applied when thumbnailing too.
@@ -800,7 +800,7 @@
 	$config['image_identification_google'] = true;
 	// Anime/manga search engine.
 	$config['image_identification_iqdb'] = false;
-	
+
 	// Set this to true if you're using a BSD
 	$config['bsd_md5'] = false;
 
@@ -982,9 +982,10 @@
 	// jQuery, you should first empty the array so that "js/query.min.js" can be the first, and then re-add
 	// "js/inline-expanding.js" or else the inline-expanding script might not interact properly with other
 	// scripts.
-	// $config['additional_javascript'] = array();
-	// $config['additional_javascript'][] = 'js/jquery.min.js';
-	// $config['additional_javascript'][] = 'js/inline-expanding.js';
+	$config['additional_javascript'] = array();
+	$config['additional_javascript'][] = 'js/jquery.min.js';
+	$config['additional_javascript'][] = 'js/inline-expanding.js';
+	$config['additional_javascript'][] = 'js/rules-popup.js';
 	// $config['additional_javascript'][] = 'js/auto-reload.js';
 	// $config['additional_javascript'][] = 'js/post-hover.js';
 	// $config['additional_javascript'][] = 'js/style-select.js';
@@ -1189,7 +1190,7 @@
 
 	// Website favicon.
 	// $config['url_favicon'] = '/favicon.gif';
-	
+
 	// Try not to build pages when we shouldn't have to.
 	$config['try_smarter'] = true;
 
@@ -1501,21 +1502,21 @@
 		'convert_args',
 		'db>password',
 	);
-	
+
 	$config['mod']['config'][JANITOR] = array(
 		'!', // Allow editing ONLY the variables listed (in this case, nothing).
 	);
-	
+
 	$config['mod']['config'][MOD] = array(
 		'!', // Allow editing ONLY the variables listed (plus that in $config['mod']['config'][JANITOR]).
 		'global_message',
 	);
-	
+
 	// Example: Disallow ADMIN from editing (and viewing) $config['db']['password'].
 	// $config['mod']['config'][ADMIN] = array(
 	// 	'db>password',
 	// );
-	
+
 	// Example: Allow ADMIN to edit anything other than $config['db']
 	// (and $config['mod']['config'][DISABLED]).
 	// $config['mod']['config'][ADMIN] = array(
@@ -1550,7 +1551,7 @@
 
 	// Limit of search results
     $config['search']['search_limit'] = 100;
-		
+
 	// Boards for searching
     //$config['search']['boards'] = array('a', 'b', 'c', 'd', 'e');
 
@@ -1568,7 +1569,7 @@
 
 	// event_handler('post', function($post) {
 	// 	// do something else
-	// 	
+	//
 	// 	// return an error (reject post)
 	// 	return 'Sorry, you cannot post that!';
 	// });

--- a/js/rules-popup.js
+++ b/js/rules-popup.js
@@ -1,0 +1,52 @@
+/*
+ * rules-popup.js
+ * https://github.com/mkwia/lainchan/js/rules-popup.js
+ *
+ * Forces user to accept rules from /rules.txt on first welcome
+ *
+ * Released under NO LINENCE [free to use, reproduce, modify, share for all purposes]
+ * 2016 mkwia <github.com/mkwia>
+ *
+ * Usage:
+ *   $config['additional_javascript'][] = 'js/jquery.min.js';
+ *   $config['additional_javascript'][] = 'js/rules-popup.js';
+ *
+ */
+
+$(function() {
+    if (typeof localStorage.rulesAccepted === "undefined") + function(c) {
+        var d = $("<div id='rules'>").prependTo("body").width("80%").height("80%")
+            .css("z-index", 9999).css("position", "fixed")
+            .css("top", "50%").css("bottom", 0).css("left", "50%").css("right", 0)
+            .css("margin-top", "-40vh").css("margin-left", "-40%")
+            .css("background", "black")
+            .css("text-align", "center").css("font-family", "sans-serif")
+            .css("font-size", "14px").css("color", "white")
+
+        d.html("" +
+
+            "<div style='font-size: 40px; line-height: 60px; position: absolute; top: 0px; height: 60px; width: 100%;'>lainchan rule agreement</div>" +
+
+            "<div style='text-align: left; position: absolute; bottom: 80px; top: 60px;" +
+            "width: 100%; background-color: #ddd; overflow: auto; font-family: serif; color: #444;'>" +
+            "<div style='padding: 10px; white-space: pre-wrap; font-size: 12px;' id='rules-actual'>" +
+            "</div>" +
+            "</div>" +
+
+            "<div style='bottom: 0px; height: 80px; width: 100%; position: absolute;'>" +
+            "<div style='line-height: 40px;'>If you accept the rules, retype the captcha and press ACCEPT.</div>" +
+            "<div style='height: 40px;'><div style='display: inline-block; border: 1px solid white; font-family: serif; padding: 3px;'>" + c + "</div>" +
+            "<form onsubmit=\"if ($('#captcha').val() == '" + c + "') { localStorage.rulesAccepted = 1; $('#rules').remove(); } return false;\"" +
+            " style='display: inline-block;'>" +
+            "<input type='text' id='captcha' style='width: 100px;' />" +
+            "<input type='submit' value='ACCEPT' />" +
+            "</form>" +
+            "</div>" +
+            "</div>" +
+
+            "");
+
+        $("#rules-actual").load("/rules.txt");
+
+    }("faggotry1234");
+});

--- a/rules.txt
+++ b/rules.txt
@@ -1,0 +1,50 @@
+GLOBAL RULES
+    Do not post in or view any boards if you are under 18 years of age.
+    If you break the rules we will delete your post. Do it repeatedly and you'll be derezzed.
+    Do not call for mods, or announce reports in a thread.
+    Always argue in good faith and avoid using personal attacks.
+    You should always elaborate on your opinions rather than just spilling the soykaf.
+    Don't respond with aggression to perceived flames or trolls (or at all.)
+    Do not whine and cry about 8chan, "quality", "invasions", "newfags", mods, bans, or kalyx outside of /q/.
+    Do not spam or advertise unrelated content.
+    Do not post child pornography or questionable 2D/3DCG/3DPG sexual depictions of children. This includes "child models".
+    If you must post it, spoiler any NSFW content and make sure it's relevant to the discussion.
+    Do not upload malicious archives.
+    Read the rules again. /* infinite iteration will fix later */
+
+
+PRO TIPS FOR MAXIMUM FUN:
+    The mods are not on powertrips, they are friendly and are trying to ensure the quality of lainchan, not belittle your ideas.
+    Lainchan is a place to have your voice heard but not a place for you to drown out others' voices.
+    Mods usually ask each other for opinions before doing anything. We hate having to ban someone.
+    Just relax and try to have fun. Jokes are always welcome.
+    Visit a board you've never been to. Try out /random/.
+    Max file size is 35 mb.
+    PDF, ePub, and webm are supported across the boards.
+    We ALWAYS need contributors to our board software, located on github
+    Dice rolling: posting in the email field with the form "dice XdY+/-Z" will result in X Y-sided dice rolled and summed, with the modifier Z added, the result is displayed at the top of the post body.
+    Be smart when posting about potentially illegal activities.
+
+
+Boards
+    /cyb/ is the general cyberpunk board for the discussion of the philosophy and anything else you can think of as being "cyberpunk".
+    /λ/ is the programming board.
+        Hard technical discussion of software development and project ideas is the only intended purpose of this board.
+        The Beginner's General is where all questions concerning novice programming should go, unless there is a more specific thread for your interests.
+    /tech/ is for the discussion of consumer technology.
+        Discussion concerning programs not intimately related to programming belongs on /tech/.
+    /zzz/ is the board for the discussion of dreams and dreaming techniques.
+    /drg/ is the board for discussing your waifu's experiences with drug usage, including buying and selling.
+    /lit/ is the board for reading, writing, and sharing written works of art.
+    /civ/ is for the discussion of politics, civic affairs and similar topics.
+    /diy/ is for the discussion of electronics and the construction and modification thereof.
+        The construction and modification of objects that are not electronic is also welcomed.
+        Cooking is one example of a topic that would fit on /diy/.
+    /art/ is the board for the discussion of other forms of art, including music, movies, and television.
+    /w/ is the board for the discussion of Japanese culture and anime.
+    /r/ is the board for the discussion of topics that do not have a dedicated board. It is not for purely random threads.
+    /layer/ is the ddt board. For more information see the sticky on the board or the official how-to guide.
+    /q/ is the questions board.
+        In specific, questions about the moderation, the quality of Lainchan, feature requests, and other questions about the website are valid.
+    Keep discussion rational. It's why we're here.
+    When in doubt about the topic of a board, lurk it for a while and check the catalog to get an idea of it.


### PR DESCRIPTION
### How to use:
- make sure `$config['additional_javascript'][] = 'js/jquery.min.js';` is in _instance-config.php_
- add `$config['additional_javascript'][] = 'js/rules-popup.js';` directly after the aforementioned line in _instance-config.php_
- put a plaintext .txt version of the rules (and/or a special welcome message that should only appear in the popup) in the root directory (or modify `.load("/rules.txt");` in _rules-popup.js_

### Notes
- wrote this as it was mentioned in the mumble meeting
