### PR TITLE
Priority Banners (issue #57)

### DIFF
--- a/b.php
+++ b/b.php
@@ -1,21 +1,47 @@
 <?php
-//renaming to b.php
-$dir = "banners/";
-$files = scandir($dir);
-$images = array_diff($files, array('.', '..'));
-$name = $images[array_rand($images)];
+// This script assumes there is at least one normal (non-priority)
+// banner!
 
-// snags the extension
-$img_extension = pathinfo($name, PATHINFO_EXTENSION);
+// Get the files in a directory, returns null if the directory does
+// not exist.
+function getFilesInDirectory($dir) {
+    if (! is_dir($dir)) {
+        return null;
+    }
 
-// send the right headers
-header('Cache-Control: no-cache, no-store, must-revalidate'); // HTTP 1.1
-header('Pragma: no-cache'); // HTTP 1.0
-header('Expires: 0'); // Proxies
-header("Content-type: image/" . $img_extension);
-header("Content-Disposition: inline; filename=" . $name);
+    return array_diff(scandir($dir), array('.', '..'));
+}
 
-// readfile displays the image, passthru seems to spits stream.
-readfile($dir.$name);
-exit;
+// Serve a random banner and exit.
+function serveRandomBanner($dir, $files) {
+    $name = $files[array_rand($files)];
+
+    // snags the extension
+    $ext = pathinfo($name, PATHINFO_EXTENSION);
+
+    // send the right headers
+    header('Cache-Control: no-cache, no-store, must-revalidate'); // HTTP 1.1
+    header('Pragma: no-cache'); // HTTP 1.0
+    header('Expires: 0'); // Proxies
+    header("Content-type: image/" . ext);
+    header("Content-Disposition: inline; filename=" . $name);
+
+    // readfile displays the image, passthru seems to spits stream.
+    readfile($dir.$name);
+    exit;
+}
+
+// Get all the banners
+$bannerDir = "banners/";
+$priorityDir = "banners_priority/";
+
+$banners = getFilesInDirectory($bannerDir);
+$priority = getFilesInDirectory($priorityDir);
+
+// If there are priority banners, serve 1/3rd of the time.
+if($priority !== null && count($priority) !== 0 && rand(0,2) === 0) {
+    serveRandomBanner($priorityDir, $priority);
+}
+
+serveRandomBanner($bannerDir, $banners);
 ?>

--- a/banners.php
+++ b/banners.php
@@ -4,14 +4,19 @@
 </head>
 <body>
 <?php
-if ($handle = opendir('banners')) {
-    while (false !== ($entry = readdir($handle))) {
-        if ($entry != "." && $entry != "..") {
-            echo "<a href=\"banners/$entry\"><img src=\"banners/$entry\" alt=\"$entry\" style=\"width:348px;height:128px\"></a> ";
+function listBannersInDir($dir) {
+    if ($handle = opendir($dir)) {
+        while (false !== ($entry = readdir($handle))) {
+            if ($entry != "." && $entry != "..") {
+                echo "<a href=\"$dir/$entry\"><img src=\"$dir/$entry\" alt=\"$entry\" style=\"width:348px;height:128px\"></a> ";
+            }
         }
+        closedir($handle);
     }
-    closedir($handle);
 }
+
+listBannersInDir("banners_priority");
+listBannersInDir("banners");
 ?>
 </body>
 </html>


### PR DESCRIPTION
Adds support for a second banner directory, "banners_priority", which is given additional weight when selecting a banner. If priority banners exist, they will be chosen from 33% of the time, and normal banners 66%.

This may not seem like a "priority", but consider the before and after for a single banner, assuming 100 total:

- **Before:** that banner has a 1% chance of being shown.
- **After:** if that banner is a priority banner, it has a 33% chance.

So this does make priority banners disproportionately more likely, assuming normal banners >> priority banners. 

## Issue
Closes #57.