### PR TITLE
This prevents a crash due to instance-config.php not existing

### DIFF
--- a/install.php
+++ b/install.php
@@ -6,7 +6,7 @@ define('VERSION', '4.9.93');
 if (fopen('inc/instance-config.php' , 'a') === false) {
 	print('install.php does not have permission to write to /inc/, without permission the installer cannot continue');
 	exit();
-	}
+}
 
 require 'inc/functions.php';
 

--- a/install.php
+++ b/install.php
@@ -3,6 +3,11 @@
 // Installation/upgrade file	
 define('VERSION', '4.9.93');
 
+if (fopen('inc/instance-config.php' , 'a') === false) {
+	print('install.php does not have permission to write to /inc/, without permission the installer cannot continue');
+	exit();
+	}
+
 require 'inc/functions.php';
 
 $step = isset($_GET['step']) ? round($_GET['step']) : 0;


### PR DESCRIPTION
The installer will now check if the file exists and if not creates the file

This is important, there's a small enough developer base for lainchan as is, we don't need to make contributing code any harder than it already is, I spent like eight hours just setting lainchan up
(granted I've never web developed before)
and I want to make sure nobody has the same problem from here on out