### PR TITLE
Typo in variable name in mod area

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1277,7 +1277,7 @@ function mod_move($originBoard, $postID) {
 			$query = prepare('SELECT `target` FROM ``cites`` WHERE `target_board` = :board AND `board` = :board AND `post` = :post');
 			$query->bindValue(':board', $originBoard);
 			$query->bindValue(':post', $post['id'], PDO::PARAM_INT);
-			$query->execute() or error(db_error($qurey));
+			$query->execute() or error(db_error($query));
 			
 			// correct >>X links
 			while ($cite = $query->fetch(PDO::FETCH_ASSOC)) {


### PR DESCRIPTION
A typo in the thread moving function might be the source of missing error messages though it seems unlikely.