### PR TITLE
Fixed catalog.html option values so mixItUp will sort threads

### DIFF
--- a/templates/themes/catalog/catalog.html
+++ b/templates/themes/catalog/catalog.html
@@ -29,9 +29,9 @@
 
 		<span>{% trans 'Sort by' %}: </span>
 		<select id="sort_by" style="display: inline-block">
-			<option selected value="bump-order">{% trans 'Bump order' %}</option>
-			<option value="creation-date">{% trans 'Creation date' %}</option>
-			<option value="reply-count">{% trans 'Reply count' %}</option>
+			<option selected value="bump:desc">{% trans 'Bump order' %}</option>
+			<option value="time:desc">{% trans 'Creation date' %}</option>
+			<option value="reply:desc">{% trans 'Reply count' %}</option>
 			<option value="random">{% trans 'Random' %}</option>
 		</select>
 


### PR DESCRIPTION
Lainchan currently can't sort threads in the catalog view because the option values are incorrect. I've added the correct option values so sorting will work now.