### PR TITLE
Responsive banner images

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -88,6 +88,15 @@ div.lain_banner{
     position: absolute;
 }
 
+img.lain_banner{
+  max-width: 100vw;
+}
+
+@media screen and (max-width: 768px) {
+  body {
+    padding-top: 50px;
+  }
+}
 
 /* === GENERAL TAG SETTINGS === */
 


### PR DESCRIPTION
On mobile devices the banner images are blocked by the menu and go outside the screen, so I made them adapt to the screensize. It also adds some padding between the header image and the menu on smaller devices.

Tested on Google Nexus 5 and Desktop.