### PR TITLE
Show whether threads are locked on the catalog page

### DIFF
--- a/templates/themes/catalog/catalog.html
+++ b/templates/themes/catalog/catalog.html
@@ -65,7 +65,7 @@
                                                  id="img-{{ post.id }}" data-subject="{% if post.subject %}{{ post.subject|e }}{% endif %}" data-name="{{ post.name|e }}" data-muhdifference="{{ post.muhdifference }}" class="{{post.board}} thread-image" title="{{post.bump|date('%b %d %H:%M')}}">
                                         </a>
                                                 <div class="replies">
-                                                        <strong>R: {{ post.reply_count }} / I: {{ post.image_count }}{% if post.sticky %} (sticky){% endif %}</strong>
+                                                  <strong>R: {{ post.reply_count }} / I: {{ post.image_count }}{% if post.sticky %} (sticky){% endif %}{% if post.locked %} <span class="fa fa-lock">&nbsp;</span>{% endif %}</strong>
                                                         {% if post.subject %}
 								<p class="intro">
 									<span class="subject">


### PR DESCRIPTION
This change adds a lock indicator to locked threads on the catalog page.