### PR TITLE
Change radio channel from "everything" to "cyberia".

### DIFF
--- a/static/lain.mp3.m3u
+++ b/static/lain.mp3.m3u
@@ -1,1 +1,1 @@
-https://lainon.life/radio/everything.mp3
+https://lainon.life/radio/cyberia.mp3

--- a/static/lain.ogg.m3u
+++ b/static/lain.ogg.m3u
@@ -1,1 +1,1 @@
-https://lainon.life/radio/everything.ogg
+https://lainon.life/radio/cyberia.ogg


### PR DESCRIPTION
I've added a new channel for swing music, so that's also now in the rotation for the "everything" channel.  I've also added a "cyberia" channel which is everything-but-swing, so if you'd like to keep the radio as it is (at least until channels happen on radio.html), this commit does that.