### PR TITLE
Use random_bytes() to generate IV where available (PHP 7.x)

### DIFF
--- a/inc/mod/auth.php
+++ b/inc/mod/auth.php
@@ -70,7 +70,11 @@ function test_password($password, $salt, $test) {
 
 function generate_salt() {
 	// 128 bits of entropy
-	return strtr(base64_encode(mcrypt_create_iv(16, MCRYPT_DEV_URANDOM)), '+', '.');
+	if (function_exists('random_bytes')) {
+		return strtr(base64_encode(random_bytes(16)), '+', '.');
+	} else {
+		return strtr(base64_encode(mcrypt_create_iv(16, MCRYPT_DEV_URANDOM)), '+', '.');
+	}
 }
 
 function login($username, $password) {


### PR DESCRIPTION
Newer iterations of PHP 7.x have the function mcrypt_create_iv() marked as deprecated, which interrupts functions on mod.php.  This makes the generate_salt() function use random_bytes() where available, falling back to the old mcrypt function if random_bytes() is not available, being that random_bytes() is a PHP 7-only function.