### PR TITLE
Fixes update notice functionality

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -120,7 +120,7 @@ function mod_dashboard() {
 
 			if ($response) {
 				$currentVersion = $config['version'];
-				$latestVersion  = getVersionFromResponse($code);
+				$latestVersion  = getVersionFromResponse($response);
 
 				if ($latestVersion) {
 					$latest  = getNumbersFromVersion($latestVersion);

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -111,47 +111,29 @@ function mod_dashboard() {
 		if (!$config['version'])
 			error(_('Could not find current version! (Check .installed)'));
 		
+		$latest = false;
+
 		if (isset($_COOKIE['update'])) {
 			$latest = unserialize($_COOKIE['update']);
 		} else {
-			$ctx = stream_context_create(array('http' => array('timeout' => 5)));
-			if ($code = @file_get_contents('http://engine.vichan.net/version.txt', 0, $ctx)) {
-				$ver = strtok($code, "\n");
-				
-				if (preg_match('@^// v(\d+)\.(\d+)\.(\d+)\s*?$@', $ver, $matches)) {
-					$latest = array(
-						'massive' => $matches[1],
-						'major' => $matches[2],
-						'minor' => $matches[3]
-					);
-					if (preg_match('/(\d+)\.(\d)\.(\d+)(-dev.+)?$/', $config['version'], $matches)) {
-						$current = array(
-							'massive' => (int) $matches[1],
-							'major' => (int) $matches[2],
-							'minor' => (int) $matches[3]
-						);
-						if (isset($m[4])) { 
-							// Development versions are always ahead in the versioning numbers
-							$current['minor'] --;
-						}
-						// Check if it's newer
-						if (!(	$latest['massive'] > $current['massive'] ||
-							$latest['major'] > $current['major'] ||
-								($latest['massive'] == $current['massive'] &&
-									$latest['major'] == $current['major'] &&
-									$latest['minor'] > $current['minor']
-								)))
-							$latest = false;
-					} else {
+			$response = getLatestVersionResponse();
+
+			if ($response) {
+				$currentVersion = $config['version'];
+				$latestVersion  = getVersionFromResponse($code);
+
+				if ($latestVersion) {
+					$latest  = getNumbersFromVersion($latestVersion);
+					$current = getNumbersFromVersion($currentVersion);
+
+					if (stripos($latestVersion, 'dev') !== false) {
+						$current['minor']--;
+					}
+
+					if (! version_compare($latestVersion, $currentVersion, '>')) {
 						$latest = false;
 					}
-				} else {
-					// Couldn't get latest version
-					$latest = false;
 				}
-			} else {
-				// Couldn't get latest version
-				$latest = false;
 			}
 	
 			setcookie('update', serialize($latest), time() + $config['check_updates_time'], $config['cookies']['jail'] ? $config['cookies']['path'] : '/', null, !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off', true);

--- a/templates/mod/dashboard.html
+++ b/templates/mod/dashboard.html
@@ -88,7 +88,7 @@
   <li>
     A newer version of vichan
     (<strong>v{{ newer_release.massive }}.{{ newer_release.major }}.{{ newer_release.minor }}</strong>) is available!
-    See <a href="https://engine.vichan.net">https://engine.vichan.net/</a> for upgrade instructions.
+    See <a href="https://github.com/lainchan/lainchan">GitHub</a> for upgrade instructions.
   </li>
 
 {% endif %}


### PR DESCRIPTION
[engine.vichan.net](https://engine.vichan.net) is seemingly no longer reachable, so site admins aren't being notified of new releases. To fix that, this PR introduces a few new functions:

- `getLatestVersionResponse()` to make a HTTP request for the latest version number
- `getVersionFromResponse()` to attempt to match the version number from the response
- `getNumbersFromVersion()` to parse a version number (current or latest) and return an array containing the individual parts (massive, major, minor)

`getLatestVersionResponse()` replaces the `file_get_contents()` call in `mod_dashboard()`, and `getVersionFromResponse()` and `getNumbersFromVersion()` moves the operations necessary to do those things into their own functions.

I considered combining the first two for a more generic function (i.e. `getLatestVersion()`) but decided to keep them separate so that they follow SRP, and because it might make sense later to allow for a path/error message/etc. specifically if the request fails.

Right now it uses a regular expression to get the version number. A couple alternatives I considered would be to have a file like `.latest` in the repo, or to [use the GitHub API](https://developer.github.com/v3/repos/releases/#get-the-latest-release). The former only requires a file update that could potentially be automated, while the latter requires that releases be maintained, and maybe an API key (in which case it wouldn't really be a feasible option).