### PR TITLE
Fixes type error and updates delete-stray-images.php

### DIFF
--- a/tools/delete-stray-images.php
+++ b/tools/delete-stray-images.php
@@ -27,17 +27,18 @@ foreach ($boards as $board) {
 	}
 	
 	while ($post = $query->fetch(PDO::FETCH_ASSOC)) {
-		$decoded = json_decode($post['files'], true);
-		$post = array_shift($decoded);
+		$images = json_decode($post['files'], true);
 
-		if (! $post) {
+		if (! $images) {
 			$error = json_last_error_msg() ?: 'Unknown error occurred';
 
 			exit("Failed to decode JSON: $error" . PHP_EOL);
 		}
 
-		$valid_src[] = $post['file'];
-		$valid_thumb[] = $post['thumb'];
+		foreach ($images as $image) {
+			$valid_src[] = $image['file'];
+			$valid_thumb[] = $image['thumb'];
+		}
 	}
 
 	$dir = $board['uri'] . DIRECTORY_SEPARATOR;

--- a/tools/delete-stray-images.php
+++ b/tools/delete-stray-images.php
@@ -18,17 +18,32 @@ foreach ($boards as $board) {
 	
 	openBoard($board['uri']);
 	
-	$query = query(sprintf("SELECT `file`, `thumb` FROM ``posts_%s`` WHERE `file` IS NOT NULL", $board['uri']));
+	$query = query(sprintf("SELECT `files` FROM ``posts_%s`` WHERE `files` IS NOT NULL", $board['uri']));
 	$valid_src = array();
 	$valid_thumb = array();
+
+	if (! $query) {
+		exit('Could not get results from the database' . PHP_EOL);
+	}
 	
 	while ($post = $query->fetch(PDO::FETCH_ASSOC)) {
+		$decoded = json_decode($post['files'], true);
+		$post = array_shift($decoded);
+
+		if (! $post) {
+			$error = json_last_error_msg() ?: 'Unknown error occurred';
+
+			exit("Failed to decode JSON: $error" . PHP_EOL);
+		}
+
 		$valid_src[] = $post['file'];
 		$valid_thumb[] = $post['thumb'];
 	}
+
+	$dir = $board['uri'] . DIRECTORY_SEPARATOR;
 	
-	$files_src = array_map('basename', glob($board['dir'] . $config['dir']['img'] . '*'));
-	$files_thumb = array_map('basename', glob($board['dir'] . $config['dir']['thumb'] . '*'));
+	$files_src = array_map('basename', glob($dir . $config['dir']['img'] . '*'));
+	$files_thumb = array_map('basename', glob($dir . $config['dir']['thumb'] . '*'));
 	
 	$stray_src = array_diff($files_src, $valid_src);
 	$stray_thumb = array_diff($files_thumb, $valid_thumb);
@@ -40,8 +55,8 @@ foreach ($boards as $board) {
 	
 	foreach ($stray_src as $src) {
 		$stats['deleted']++;
-		$stats['size'] = filesize($board['dir'] . $config['dir']['img'] . $src);
-		if (!file_unlink($board['dir'] . $config['dir']['img'] . $src)) {
+		$stats['size'] = filesize($dir . $config['dir']['img'] . $src);
+		if (!file_unlink($dir . $config['dir']['img'] . $src)) {
 			$er = error_get_last();
 			die("error: " . $er['message'] . "\n");
 		}
@@ -49,8 +64,8 @@ foreach ($boards as $board) {
 		
 	foreach ($stray_thumb as $thumb) {
 		$stats['deleted']++;
-		$stats['size'] = filesize($board['dir'] . $config['dir']['thumb'] . $thumb);
-		if (!file_unlink($board['dir'] . $config['dir']['thumb'] . $thumb)) {
+		$stats['size'] = filesize($dir . $config['dir']['thumb'] . $thumb);
+		if (!file_unlink($dir . $config['dir']['thumb'] . $thumb)) {
 			$er = error_get_last();
 			die("error: " . $er['message'] . "\n");
 		}


### PR DESCRIPTION
`delete-stray-images.php` was failing to because the SQL schema for board tables was updated so that the `file` and `thumb` columns merged into a JSON column, `files`. This was causing `query()` to silently fail and return false. The query has been updated to get the correct data, along with the following changes:

- Guard clauses were added to exit the script if `query()` failed for any other reason, or the result could not be decoded<sup>*</sup>
-  `$dir` variable was added to replace `$board['dir']` which is seemingly missing - I'm not sure if this is a localized issue (e.g. the index is being conditionally skipped) or the result of a change, so if someone could tell me one way or the other that'd be helpful (I'll remove this variable if it's the former)