### PR TITLE
Update dark_irc.css

### DIFF
--- a/stylesheets/dark_irc.css
+++ b/stylesheets/dark_irc.css
@@ -1,12 +1,12 @@
 html, body
 {
-	height: 90%!important;
+	height: 100%!important;
 }
 div.ban 
 {
 	width: 80%!important;
 	max-width: 80%!important;
-	height: 100%!important;
+	height: 80%!important;
 }
 iframe
 {


### PR DESCRIPTION
The CSS used for the irc page has a blank "bar" in the bottom 10% of the screen, causing usage of the irc client to be awkward since on desktop and laptop screens scrolling is required. Making the html element to be 100% of the page height and the element containing the iframe of the client to be 80% improves usability as the online irc client is fully rendered into view.